### PR TITLE
fix: field-types-components-cleanup

### DIFF
--- a/src/UI/FormComponents/FieldTypes/CustomSelectComponent.jsx
+++ b/src/UI/FormComponents/FieldTypes/CustomSelectComponent.jsx
@@ -3,27 +3,6 @@ import Select from 'react-select'
 
 import { Field } from 'formik'
 
-const onChange = (option) => {
-  form.setFieldValue(
-    field.name,
-    isMulti ? option.map((item) => item.value) : option.value
-  )
-}
-
-const getValue = (options, field, isMulti) => {
-  if (options) {
-    // Ensure field.value is an array and not null or undefined.
-    const fieldValue = Array.isArray(field.value) ? field.value : []
-
-    return isMulti
-      ? options.filter(option => fieldValue.includes(option.value))
-      : options.find(option => option.value === field.value)
-  
-  } else {
-    return isMulti ? [] : ""
-  }
-}
-
 const CustomSelectComponent = ({
   className,
   placeholder,
@@ -34,11 +13,33 @@ const CustomSelectComponent = ({
   ...props
 }) => {
   
+  const onChange = (option) => {
+    form.setFieldValue(
+      field.name,
+      isMulti ? option.map((item) => item.value) : option.value
+    )
+  }
+
+  const getValue = () => {
+    if (options) {
+      
+      // Ensure field.value is an array and not null or undefined.
+      const fieldValue = Array.isArray(field.value) ? field.value : []
+  
+      return isMulti
+        ? options.filter(option => fieldValue.includes(option.value))
+        : options.find(option => option.value === field.value)
+
+    } else {
+      return isMulti ? [] : ""
+    }
+  }
+
   return (
     <Select
       className = { className }
       name = { field.name }
-      value = { getValue(options, field, isMulti) }
+      value = { getValue() }
       onChange = { onChange }
       placeholder = { placeholder }
       options = { options }
@@ -48,7 +49,7 @@ const CustomSelectComponent = ({
   )
 }
 
-// Formik field wrapper for custom select.
+// Formik Field wrapper for custom select.
 const CustomSelect = (props) => (
   <Field component = { CustomSelectComponent } { ...props } />
 )

--- a/src/UI/FormComponents/FieldTypes/SmartFolderField.jsx
+++ b/src/UI/FormComponents/FieldTypes/SmartFolderField.jsx
@@ -6,12 +6,10 @@ const extractSecondLevelKeys = (obj) => {
   const options = []
 
   const traverse = (obj, level = 0) => {
-    
     if (level === 1) {
       Object.keys(obj).forEach((key) => {
         options.push({ value: key, label: key })
       })
-    
     } else {
       Object.values(obj).forEach((value) => {
         if (typeof value === "object") {


### PR DESCRIPTION
Fixed issue mentioned here: https://github.com/ReproModel/repromodel/pull/33#issuecomment-2132296707

renamed file "FolderQuestion" to "SmartFolderField" to match component name and fixed all imports

renamed component "SmartFreeTextField" to match file name "SmartStringField" and replaced all references

cleaned up code in FieldTypes > CustomSelectComponent.jsx

cleaned up code in FieldTypes > SmartFolderField.jsx

cleaned up code in FieldTypes > FormulaField.jsx

cleaned up code in FieldTypes > SmartFloatField.jsx

cleaned up code in FieldTypes > SmartStringField.jsx

cleaned up code in FlexibleFormField.jsx