### PR TITLE
fix: rename-module-stack

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,7 @@ import { Button, ButtonGroup } from "@mui/material";
 import "./App.css";
 
 import Header from "./components/header/header"
-import ModuleStack from "./components/module-stack/module-stack"
+import RepromodelStructure from "./components/repromodel-structure/repromodel-structure"
 import newQuestions from "../repromodel_core/choices.json";
 import { handleFileChange, handleSubmit } from "./helperFunctions/FormHelper";
 import DynamicFormBuilder from "./UI/DynamicFormBuilder";
@@ -32,7 +32,7 @@ function App() {
           <Grid container direction={"row"}>
             <Grid item xs={4} className="stackContainer">
               <Grid item className="stackFrame">
-                <ModuleStack FormikProps = { FormikProps } />
+                <RepromodelStructure FormikProps = { FormikProps } />
               </Grid>
             </Grid>
             <Grid item xs={8} className="questionairContainer">

--- a/src/components/repromodel-structure/repromodel-structure.jsx
+++ b/src/components/repromodel-structure/repromodel-structure.jsx
@@ -4,7 +4,7 @@ import React from "react"
 
 import { Container, Stack, Typography } from "@mui/material"
 
-function ModuleStack({ FormikProps }) {
+function RepromodelStructure({ FormikProps }) {
   
   return (
     <Container maxWidth = "md">
@@ -31,4 +31,4 @@ function ModuleStack({ FormikProps }) {
   )
 }
 
-export default ModuleStack
+export default RepromodelStructure


### PR DESCRIPTION
Changes Made:
- Renamed folder/component module-stack to repromodel-structure to match the UI for clarity
- updated imports/references