### PR TITLE
fix: fixed-repromodal-structure-css

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,7 @@
   border-radius: 8px;
   padding: 16px;
   box-shadow: 0px 15px 35px hsla(0, 0%, 0%, 0.3);
+  overflow-y: scroll;
 }
 
 .questionairContainer {


### PR DESCRIPTION
Added overflow-y: scroll

to resolve the issue below:

<img width="497" alt="Screenshot 2024-05-27 at 1 12 49 PM" src="https://github.com/ReproModel/repromodel/assets/20110627/39b1b801-905a-41fe-bff8-ea0b4df0cf58">
