### PR TITLE
fix: style-active-tab

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -79,8 +79,3 @@ button {
 button:hover {
   border-color: #646cff;
 }
-
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,9 +45,9 @@ function App() {
               
               <Box sx = { { position: "absolute", top: 32, right: 48, zIndex: 100 } }>
                 <ButtonGroup variant = "contained">
-                  <Button onClick = { () => setSelectedSection("Experiment Builder") }>Experiment Builder</Button>
-                  <Button onClick = { () => setSelectedSection("Model Testing") }>Model Testing</Button>
-                  <Button onClick = { () => setSelectedSection("Progress Viewer") }>Progress Viewer</Button>
+                  <Button onClick = { () => setSelectedSection("Experiment Builder") } style = { { opacity: (selectedSection == "Experiment Builder") ? "100%" : "70%"} }>Experiment Builder</Button>
+                  <Button onClick = { () => setSelectedSection("Model Testing") } style = { { opacity: (selectedSection == "Model Testing") ? "100%" : "70%"} }>Model Testing</Button>
+                  <Button onClick = { () => setSelectedSection("Progress Viewer") } style = { { opacity: (selectedSection == "Progress Viewer") ? "100%" : "70%"} }>Progress Viewer</Button>
                 </ButtonGroup>
               </Box>
 


### PR DESCRIPTION
Changes Made:
- Replaced ugly blue ring around active tab

Before:
<img width="568" alt="Screenshot 2024-06-04 at 3 36 23 AM" src="https://github.com/ReproModel/repromodel/assets/20110627/bdd7f035-300c-4eb7-8814-bcfa715d03a6">

After:
<img width="896" alt="Screenshot 2024-06-04 at 3 34 53 AM" src="https://github.com/ReproModel/repromodel/assets/20110627/990bb6f3-8754-46f6-ab05-1b581d5e3c1c">

<img width="920" alt="Screenshot 2024-06-04 at 3 34 58 AM" src="https://github.com/ReproModel/repromodel/assets/20110627/36e49fa9-3295-4a98-ac7f-b3bf6cdb6918">

<img width="896" alt="Screenshot 2024-06-04 at 3 35 04 AM" src="https://github.com/ReproModel/repromodel/assets/20110627/ff70f340-ef89-4ff9-b5ec-94f4c85ae8f1">
