### PR TITLE
Rm 021 code extractor

### DIFF
--- a/repromodel_core/choices.json
+++ b/repromodel_core/choices.json
@@ -848,24 +848,112 @@
         }
     },
     "datasets": {
-        "cifar100Dataset": {
-            "CIFAR100Dataset": {
+        "cityscapes": {
+            "CityscapesDataset": {
                 "root": {
-                    "type": "str"
+                    "type": "str",
+                    "default": "repromodel_core/data/cityscapes"
                 },
-                "train": {
-                    "type": "bool"
+                "split": {
+                    "type": "str",
+                    "default": "train",
+                    "options": "['train', 'val', 'test']"
+                },
+                "mode": {
+                    "type": "str",
+                    "default": "fine",
+                    "options": "['fine', 'coarse']"
+                },
+                "target_type": {
+                    "type": "<unsupported>",
+                    "default": "semantic",
+                    "options": "['instance', 'semantic', 'polygon', 'color']"
                 },
                 "transform": {
-                    "type": "<class 'function'>",
+                    "type": "<unsupported>",
                     "default": null
                 },
                 "target_transform": {
-                    "type": "<class 'function'>",
+                    "type": "<unsupported>",
+                    "default": null
+                }
+            },
+            "TestCityscapesDataset": {}
+        },
+        "cifar100": {
+            "CIFAR100Dataset": {
+                "root": {
+                    "type": "str",
+                    "default": "repromodel_core/data/cifar100"
+                },
+                "train": {
+                    "type": "bool",
+                    "default": true
+                },
+                "transform": {
+                    "type": "Callable",
+                    "default": null
+                },
+                "target_transform": {
+                    "type": "Callable",
                     "default": null
                 },
                 "download": {
-                    "type": "bool"
+                    "type": "bool",
+                    "default": false
+                }
+            }
+        },
+        "eurosat": {
+            "EuroSATDataset": {
+                "root": {
+                    "type": "str",
+                    "default": "repromodel_core/data/eurosat"
+                },
+                "transform": {
+                    "type": "Callable",
+                    "default": null
+                },
+                "target_transform": {
+                    "type": "Callable",
+                    "default": null
+                },
+                "download": {
+                    "type": "bool",
+                    "default": false
+                }
+            }
+        },
+        "celeba": {
+            "CelebADataset": {
+                "root": {
+                    "type": "str",
+                    "default": "repromodel_core/data/celeba"
+                },
+                "split": {
+                    "type": "str",
+                    "default": "train",
+                    "options": "['train', 'valid', 'test', 'trainval', 'all']"
+                },
+                "target_type": {
+                    "type": [
+                        "str",
+                        "list"
+                    ],
+                    "default": "attr",
+                    "options": "['attr', 'identity', 'bbox', 'landmarks']"
+                },
+                "transform": {
+                    "type": "Callable",
+                    "default": null
+                },
+                "target_transform": {
+                    "type": "Callable",
+                    "default": null
+                },
+                "download": {
+                    "type": "bool",
+                    "default": false
                 }
             }
         },
@@ -894,29 +982,133 @@
                 }
             }
         },
-        "cifar10Dataset": {
-            "CIFAR10Dataset": {
+        "country211": {
+            "Country211Dataset": {
                 "root": {
-                    "type": "str"
+                    "type": "str",
+                    "default": "repromodel_core/data/country211"
                 },
-                "train": {
-                    "type": "bool"
+                "split": {
+                    "type": "str",
+                    "default": "trainval",
+                    "options": "['train', 'valid', 'test', 'trainval']"
                 },
                 "transform": {
-                    "type": "Compose",
+                    "type": "Callable",
                     "default": null
                 },
                 "target_transform": {
-                    "type": "Compose",
+                    "type": "Callable",
                     "default": null
                 },
                 "download": {
-                    "type": "bool"
+                    "type": "bool",
+                    "default": false
                 }
             }
         },
-        "extendedVisionDataset": {
-            "ExtendedVisionDataset": {}
+        "dtd": {
+            "DTDDataset": {
+                "root": {
+                    "type": "str",
+                    "default": "repromodel_core/data/dtd"
+                },
+                "split": {
+                    "type": "str",
+                    "default": "trainval",
+                    "options": "['train', 'val', 'test', 'trainval']"
+                },
+                "transform": {
+                    "type": "Callable",
+                    "default": null
+                },
+                "target_transform": {
+                    "type": "Callable",
+                    "default": null
+                },
+                "download": {
+                    "type": "bool",
+                    "default": false
+                }
+            }
+        },
+        "cifar10": {
+            "CIFAR10Dataset": {
+                "root": {
+                    "type": "str",
+                    "default": "repromodel_core/data/cifar10"
+                },
+                "train": {
+                    "type": "bool",
+                    "default": true
+                },
+                "transform": {
+                    "type": "Callable",
+                    "default": null
+                },
+                "target_transform": {
+                    "type": "Callable",
+                    "default": null
+                },
+                "download": {
+                    "type": "bool",
+                    "default": false
+                }
+            }
+        },
+        "caltech101": {
+            "Caltech101Dataset": {
+                "root": {
+                    "type": "str",
+                    "default": "repromodel_core/data/caltech101"
+                },
+                "target_type": {
+                    "type": "str",
+                    "default": "category",
+                    "options": "['category', 'annotation']"
+                },
+                "transform": {
+                    "type": "Callable",
+                    "default": null
+                },
+                "target_transform": {
+                    "type": "Callable",
+                    "default": null
+                },
+                "download": {
+                    "type": "bool",
+                    "default": false
+                }
+            }
+        },
+        "emnist": {
+            "EMNISTDataset": {
+                "root": {
+                    "type": "str",
+                    "default": "repromodel_core/data/emnist"
+                },
+                "split": {
+                    "type": "str",
+                    "default": "byclass",
+                    "options": "['byclass', 'bymerge', 'balanced', 'letters', 'digits', 'mnist']"
+                },
+                "expand_to_rgb": {
+                    "type": "bool",
+                    "default": false
+                },
+                "transform": {
+                    "type": "Callable",
+                    "default": null
+                },
+                "target_transform": {
+                    "type": "Callable",
+                    "default": null
+                },
+                "download": {
+                    "type": "bool",
+                    "default": false
+                }
+            }
         },
         "vocSegmentation": {
             "VOCSegmentationDataset": {
@@ -980,1822 +1172,28 @@
                 }
             }
         },
-        "caltech101_RM": {
-            "Caltech101_RM": {
+        "caltech256": {
+            "Caltech256Dataset": {
                 "root": {
                     "type": "str",
-                    "default": "repromodel_core/data/caltech101"
-                },
-                "input_folder": {
-                    "type": "str",
-                    "default": "101_ObjectCategories"
-                },
-                "target_folder": {
-                    "type": "str",
-                    "default": "Annotations"
-                },
-                "download": {
-                    "type": "bool",
-                    "default": true
-                }
-            }
-        },
-        "torchvision>datasets": {
-            "CIFAR10": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "train": {
-                    "type": "bool",
-                    "default": true
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "CIFAR100": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "train": {
-                    "type": "bool",
-                    "default": true
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "CLEVRClassification": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "CREStereo": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "Caltech101": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
+                    "default": "repromodel_core/data/caltech256"
                 },
                 "target_type": {
-                    "type": "typing.Union[typing.List[str], str]",
-                    "default": "category"
+                    "type": "str",
+                    "default": "category",
+                    "options": "['category']"
                 },
                 "transform": {
-                    "type": "typing.Optional[typing.Callable]",
+                    "type": "Callable",
                     "default": null
                 },
                 "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
+                    "type": "Callable",
                     "default": null
                 },
                 "download": {
                     "type": "bool",
                     "default": false
-                }
-            },
-            "Caltech256": {
-                "root": {
-                    "type": "str",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "CarlaStereo": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "CelebA": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "target_type": {
-                    "type": "typing.Union[typing.List[str], str]",
-                    "default": "attr"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "Cityscapes": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "mode": {
-                    "type": "str",
-                    "default": "fine"
-                },
-                "target_type": {
-                    "type": "typing.Union[typing.List[str], str]",
-                    "default": "instance"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "CocoCaptions": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "annFile": {
-                    "type": "str",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "CocoDetection": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "annFile": {
-                    "type": "str",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "Country211": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "DTD": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "partition": {
-                    "type": "int",
-                    "default": 1
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "DatasetFolder": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "loader": {
-                    "type": "typing.Callable[[str], typing.Any]",
-                    "default": null
-                },
-                "extensions": {
-                    "type": "typing.Optional[typing.Tuple[str, ...]]",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "is_valid_file": {
-                    "type": "typing.Optional[typing.Callable[[str], bool]]",
-                    "default": null
-                },
-                "allow_empty": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "EMNIST": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": null
-                },
-                "kwargs": {
-                    "type": "typing.Any",
-                    "default": null
-                }
-            },
-            "ETH3DStereo": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "EuroSAT": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "FER2013": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "FGVCAircraft": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "trainval"
-                },
-                "annotation_level": {
-                    "type": "str",
-                    "default": "variant"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "FakeData": {
-                "size": {
-                    "type": "int",
-                    "default": 1000
-                },
-                "image_size": {
-                    "type": "typing.Tuple[int, int, int]",
-                    "default": [
-                        3,
-                        224,
-                        224
-                    ]
-                },
-                "num_classes": {
-                    "type": "int",
-                    "default": 10
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "random_offset": {
-                    "type": "int",
-                    "default": 0
-                }
-            },
-            "FallingThingsStereo": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "variant": {
-                    "type": "str",
-                    "default": "single"
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "FashionMNIST": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "train": {
-                    "type": "bool",
-                    "default": true
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "Flickr30k": {
-                "root": {
-                    "type": "str",
-                    "default": null
-                },
-                "ann_file": {
-                    "type": "str",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "Flickr8k": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "ann_file": {
-                    "type": "str",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "Flowers102": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "FlyingChairs": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "FlyingThings3D": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "pass_name": {
-                    "type": "str",
-                    "default": "clean"
-                },
-                "camera": {
-                    "type": "str",
-                    "default": "left"
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "Food101": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "GTSRB": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "HD1K": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "HMDB51": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "annotation_path": {
-                    "type": "str",
-                    "default": null
-                },
-                "frames_per_clip": {
-                    "type": "int",
-                    "default": null
-                },
-                "step_between_clips": {
-                    "type": "int",
-                    "default": 1
-                },
-                "frame_rate": {
-                    "type": "typing.Optional[int]",
-                    "default": null
-                },
-                "fold": {
-                    "type": "int",
-                    "default": 1
-                },
-                "train": {
-                    "type": "bool",
-                    "default": true
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "_precomputed_metadata": {
-                    "type": "typing.Optional[typing.Dict[str, typing.Any]]",
-                    "default": null
-                },
-                "num_workers": {
-                    "type": "int",
-                    "default": 1
-                },
-                "_video_width": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_video_height": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_video_min_dimension": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_audio_samples": {
-                    "type": "int",
-                    "default": 0
-                },
-                "output_format": {
-                    "type": "str",
-                    "default": "THWC"
-                }
-            },
-            "INaturalist": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "version": {
-                    "type": "str",
-                    "default": "2021_train"
-                },
-                "target_type": {
-                    "type": "typing.Union[typing.List[str], str]",
-                    "default": "full"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "ImageFolder": {
-                "root": {
-                    "type": "str",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "loader": {
-                    "type": "typing.Callable[[str], typing.Any]",
-                    "default": "<function default_loader at 0x123a73ca0>"
-                },
-                "is_valid_file": {
-                    "type": "typing.Optional[typing.Callable[[str], bool]]",
-                    "default": null
-                },
-                "allow_empty": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "ImageNet": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "kwargs": {
-                    "type": "typing.Any",
-                    "default": null
-                }
-            },
-            "Imagenette": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "size": {
-                    "type": "str",
-                    "default": "full"
-                },
-                "download": {
-                    "type": "int, float",
-                    "default": false
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "InStereo2k": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "KMNIST": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "train": {
-                    "type": "bool",
-                    "default": true
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "Kinetics": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "frames_per_clip": {
-                    "type": "int",
-                    "default": null
-                },
-                "num_classes": {
-                    "type": "str",
-                    "default": "400"
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "frame_rate": {
-                    "type": "typing.Optional[int]",
-                    "default": null
-                },
-                "step_between_clips": {
-                    "type": "int",
-                    "default": 1
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "extensions": {
-                    "type": "typing.Tuple[str, ...]",
-                    "default": [
-                        "avi",
-                        "mp4"
-                    ]
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                },
-                "num_download_workers": {
-                    "type": "int",
-                    "default": 1
-                },
-                "num_workers": {
-                    "type": "int",
-                    "default": 1
-                },
-                "_precomputed_metadata": {
-                    "type": "typing.Optional[typing.Dict[str, typing.Any]]",
-                    "default": null
-                },
-                "_video_width": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_video_height": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_video_min_dimension": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_audio_samples": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_audio_channels": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_legacy": {
-                    "type": "bool",
-                    "default": false
-                },
-                "output_format": {
-                    "type": "str",
-                    "default": "TCHW"
-                }
-            },
-            "Kitti": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "train": {
-                    "type": "bool",
-                    "default": true
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "Kitti2012Stereo": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "Kitti2015Stereo": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "KittiFlow": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "LFWPairs": {
-                "root": {
-                    "type": "str",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "10fold"
-                },
-                "image_set": {
-                    "type": "str",
-                    "default": "funneled"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "LFWPeople": {
-                "root": {
-                    "type": "str",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "10fold"
-                },
-                "image_set": {
-                    "type": "str",
-                    "default": "funneled"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "LSUN": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "classes": {
-                    "type": "typing.Union[str, typing.List[str]]",
-                    "default": "train"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "LSUNClass": {
-                "root": {
-                    "type": "str",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "MNIST": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "train": {
-                    "type": "bool",
-                    "default": true
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "Middlebury2014Stereo": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "calibration": {
-                    "type": "typing.Optional[str]",
-                    "default": "perfect"
-                },
-                "use_ambient_views": {
-                    "type": "bool",
-                    "default": false
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "MovingMNIST": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "typing.Optional[str]",
-                    "default": null
-                },
-                "split_ratio": {
-                    "type": "int",
-                    "default": 10
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "Omniglot": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "background": {
-                    "type": "bool",
-                    "default": true
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "OxfordIIITPet": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "trainval"
-                },
-                "target_types": {
-                    "type": "typing.Union[typing.Sequence[str], str]",
-                    "default": "category"
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "PCAM": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "PhotoTour": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "name": {
-                    "type": "str",
-                    "default": null
-                },
-                "train": {
-                    "type": "bool",
-                    "default": true
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "Places365": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train-standard"
-                },
-                "small": {
-                    "type": "bool",
-                    "default": false
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "loader": {
-                    "type": "typing.Callable[[str], typing.Any]",
-                    "default": "<function default_loader at 0x123a73ca0>"
-                }
-            },
-            "QMNIST": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "what": {
-                    "type": "typing.Optional[str]",
-                    "default": null
-                },
-                "compat": {
-                    "type": "bool",
-                    "default": true
-                },
-                "train": {
-                    "type": "bool",
-                    "default": true
-                },
-                "kwargs": {
-                    "type": "typing.Any",
-                    "default": null
-                }
-            },
-            "RenderedSST2": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "SBDataset": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "image_set": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "mode": {
-                    "type": "str",
-                    "default": "boundaries"
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "SBU": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": true
-                }
-            },
-            "SEMEION": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": true
-                }
-            },
-            "STL10": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "folds": {
-                    "type": "typing.Optional[int]",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "SUN397": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "SVHN": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "SceneFlowStereo": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "variant": {
-                    "type": "str",
-                    "default": "FlyingThings3D"
-                },
-                "pass_name": {
-                    "type": "str",
-                    "default": "clean"
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "Sintel": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "pass_name": {
-                    "type": "str",
-                    "default": "clean"
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "SintelStereo": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "pass_name": {
-                    "type": "str",
-                    "default": "final"
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "StanfordCars": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "UCF101": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "annotation_path": {
-                    "type": "str",
-                    "default": null
-                },
-                "frames_per_clip": {
-                    "type": "int",
-                    "default": null
-                },
-                "step_between_clips": {
-                    "type": "int",
-                    "default": 1
-                },
-                "frame_rate": {
-                    "type": "typing.Optional[int]",
-                    "default": null
-                },
-                "fold": {
-                    "type": "int",
-                    "default": 1
-                },
-                "train": {
-                    "type": "bool",
-                    "default": true
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "_precomputed_metadata": {
-                    "type": "typing.Optional[typing.Dict[str, typing.Any]]",
-                    "default": null
-                },
-                "num_workers": {
-                    "type": "int",
-                    "default": 1
-                },
-                "_video_width": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_video_height": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_video_min_dimension": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_audio_samples": {
-                    "type": "int",
-                    "default": 0
-                },
-                "output_format": {
-                    "type": "str",
-                    "default": "THWC"
-                }
-            },
-            "USPS": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "train": {
-                    "type": "bool",
-                    "default": true
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "VOCDetection": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "year": {
-                    "type": "str",
-                    "default": "2012"
-                },
-                "image_set": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "VOCSegmentation": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "year": {
-                    "type": "str",
-                    "default": "2012"
-                },
-                "image_set": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "VisionDataset": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path, NoneType]",
-                    "default": null
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "WIDERFace": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "split": {
-                    "type": "str",
-                    "default": "train"
-                },
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "download": {
-                    "type": "bool",
-                    "default": false
-                }
-            },
-            "FlowDataset": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "StereoMatchingDataset": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                },
-                "transforms": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                }
-            },
-            "CSV": {
-                "args": {
-                    "type": "unknown",
-                    "default": null
-                },
-                "kwargs": {
-                    "type": "unknown",
-                    "default": null
-                }
-            },
-            "Flickr8kParser": {
-                "root": {
-                    "type": "typing.Union[str, pathlib.Path]",
-                    "default": null
-                }
-            },
-            "DistributedSampler": {
-                "dataset": {
-                    "type": "typing.Sized",
-                    "default": null
-                },
-                "num_replicas": {
-                    "type": "typing.Optional[int]",
-                    "default": null
-                },
-                "rank": {
-                    "type": "typing.Optional[int]",
-                    "default": null
-                },
-                "shuffle": {
-                    "type": "bool",
-                    "default": false
-                },
-                "group_size": {
-                    "type": "int",
-                    "default": 1
-                }
-            },
-            "RandomClipSampler": {
-                "video_clips": {
-                    "type": "VideoClips",
-                    "default": null
-                },
-                "max_clips_per_video": {
-                    "type": "int",
-                    "default": null
-                }
-            },
-            "UniformClipSampler": {
-                "video_clips": {
-                    "type": "VideoClips",
-                    "default": null
-                },
-                "num_clips_per_video": {
-                    "type": "int",
-                    "default": null
-                }
-            },
-            "VideoClips": {
-                "video_paths": {
-                    "type": "typing.List[str]",
-                    "default": null
-                },
-                "clip_length_in_frames": {
-                    "type": "int",
-                    "default": 16
-                },
-                "frames_between_clips": {
-                    "type": "int",
-                    "default": 1
-                },
-                "frame_rate": {
-                    "type": "typing.Optional[float]",
-                    "default": null
-                },
-                "_precomputed_metadata": {
-                    "type": "typing.Optional[typing.Dict[str, typing.Any]]",
-                    "default": null
-                },
-                "num_workers": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_video_width": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_video_height": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_video_min_dimension": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_video_max_dimension": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_audio_samples": {
-                    "type": "int",
-                    "default": 0
-                },
-                "_audio_channels": {
-                    "type": "int",
-                    "default": 0
-                },
-                "output_format": {
-                    "type": "str",
-                    "default": "THWC"
-                }
-            },
-            "StandardTransform": {
-                "transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
-                },
-                "target_transform": {
-                    "type": "typing.Optional[typing.Callable]",
-                    "default": null
                 }
             }
         }
@@ -7362,7 +5760,7 @@
                 },
                 "preprocess_text_fn": {
                     "type": "typing.Callable[[typing.List[str], typing.Any, int], typing.Union[typing.Dict[str, torch.Tensor], typing.Tuple[typing.Dict[str, torch.Tensor], typing.Optional[torch.Tensor]]]]",
-                    "default": "<function _preprocess_text at 0x122d233a0>"
+                    "default": "<function _preprocess_text at 0x12c7064c0>"
                 },
                 "idf": {
                     "type": "bool",
@@ -9430,12 +7828,152 @@
                     "RGB"
                 ]
             },
+            "cityscapes>CityscapesDataset": {
+                "task": [
+                    "segmentation"
+                ],
+                "subtask": [
+                    "semantic"
+                ],
+                "modality": [
+                    "images"
+                ],
+                "submodality": [
+                    "RGB"
+                ]
+            },
+            "cifar100>CIFAR100Dataset": {
+                "task": [
+                    "classification"
+                ],
+                "subtask": [
+                    "image"
+                ],
+                "modality": [
+                    "images"
+                ],
+                "submodality": [
+                    "RGB"
+                ]
+            },
+            "eurosat>EuroSATDataset": {
+                "task": [
+                    "classification"
+                ],
+                "subtask": [
+                    "image"
+                ],
+                "modality": [
+                    "images"
+                ],
+                "submodality": [
+                    "RGB"
+                ]
+            },
+            "celeba>CelebADataset": {
+                "task": [
+                    "classification"
+                ],
+                "subtask": [
+                    "attribute"
+                ],
+                "modality": [
+                    "images"
+                ],
+                "submodality": [
+                    "RGB"
+                ]
+            },
+            "country211>Country211Dataset": {
+                "task": [
+                    "classification"
+                ],
+                "subtask": [
+                    "image"
+                ],
+                "modality": [
+                    "images"
+                ],
+                "submodality": [
+                    "RGB"
+                ]
+            },
+            "dtd>DTDDataset": {
+                "task": [
+                    "classification"
+                ],
+                "subtask": [
+                    "texture"
+                ],
+                "modality": [
+                    "images"
+                ],
+                "submodality": [
+                    "RGB"
+                ]
+            },
+            "cifar10>CIFAR10Dataset": {
+                "task": [
+                    "classification"
+                ],
+                "subtask": [
+                    "image"
+                ],
+                "modality": [
+                    "images"
+                ],
+                "submodality": [
+                    "RGB"
+                ]
+            },
+            "caltech101>Caltech101Dataset": {
+                "task": [
+                    "classification"
+                ],
+                "subtask": [
+                    "image"
+                ],
+                "modality": [
+                    "images"
+                ],
+                "submodality": [
+                    "RGB"
+                ]
+            },
+            "emnist>EMNISTDataset": {
+                "task": [
+                    "classification"
+                ],
+                "subtask": [
+                    "image"
+                ],
+                "modality": [
+                    "images"
+                ],
+                "submodality": [
+                    "grayscale"
+                ]
+            },
             "vocSegmentation>VOCSegmentationDataset": {
                 "task": [
                     "segmentation"
                 ],
                 "subtask": [
                     "semantic"
+                ],
+                "modality": [
+                    "images"
+                ],
+                "submodality": [
+                    "RGB"
+                ]
+            },
+            "caltech256>Caltech256Dataset": {
+                "task": [
+                    "classification"
+                ],
+                "subtask": [
+                    "image"
                 ],
                 "modality": [
                     "images"
@@ -9521,6 +8059,17 @@
                         "resnet_mixed_convolution>ResNetMixedConvolution",
                         "vgg13_bn>VGG13_BN",
                         "resnet50>ResNet50"
+                    ],
+                    "datasets": [
+                        "cifar100>CIFAR100Dataset",
+                        "eurosat>EuroSATDataset",
+                        "celeba>CelebADataset",
+                        "country211>Country211Dataset",
+                        "dtd>DTDDataset",
+                        "cifar10>CIFAR10Dataset",
+                        "caltech101>Caltech101Dataset",
+                        "emnist>EMNISTDataset",
+                        "caltech256>Caltech256Dataset"
                     ]
                 },
                 "segmentation": {
@@ -9533,6 +8082,7 @@
                         "fcnresnet50>FCNResNet50"
                     ],
                     "datasets": [
+                        "cityscapes>CityscapesDataset",
                         "vocSegmentation>VOCSegmentationDataset"
                     ]
                 }
@@ -9652,7 +8202,29 @@
                 },
                 "semantic": {
                     "datasets": [
+                        "cityscapes>CityscapesDataset",
                         "vocSegmentation>VOCSegmentationDataset"
+                    ]
+                },
+                "image": {
+                    "datasets": [
+                        "cifar100>CIFAR100Dataset",
+                        "eurosat>EuroSATDataset",
+                        "country211>Country211Dataset",
+                        "cifar10>CIFAR10Dataset",
+                        "caltech101>Caltech101Dataset",
+                        "emnist>EMNISTDataset",
+                        "caltech256>Caltech256Dataset"
+                    ]
+                },
+                "attribute": {
+                    "datasets": [
+                        "celeba>CelebADataset"
+                    ]
+                },
+                "texture": {
+                    "datasets": [
+                        "dtd>DTDDataset"
                     ]
                 }
             },
@@ -9710,7 +8282,17 @@
                         "resnet50>ResNet50"
                     ],
                     "datasets": [
-                        "vocSegmentation>VOCSegmentationDataset"
+                        "cityscapes>CityscapesDataset",
+                        "cifar100>CIFAR100Dataset",
+                        "eurosat>EuroSATDataset",
+                        "celeba>CelebADataset",
+                        "country211>Country211Dataset",
+                        "dtd>DTDDataset",
+                        "cifar10>CIFAR10Dataset",
+                        "caltech101>Caltech101Dataset",
+                        "emnist>EMNISTDataset",
+                        "vocSegmentation>VOCSegmentationDataset",
+                        "caltech256>Caltech256Dataset"
                     ]
                 },
                 "video": {
@@ -9775,7 +8357,21 @@
                         "resnet50>ResNet50"
                     ],
                     "datasets": [
-                        "vocSegmentation>VOCSegmentationDataset"
+                        "cityscapes>CityscapesDataset",
+                        "cifar100>CIFAR100Dataset",
+                        "eurosat>EuroSATDataset",
+                        "celeba>CelebADataset",
+                        "country211>Country211Dataset",
+                        "dtd>DTDDataset",
+                        "cifar10>CIFAR10Dataset",
+                        "caltech101>Caltech101Dataset",
+                        "vocSegmentation>VOCSegmentationDataset",
+                        "caltech256>Caltech256Dataset"
+                    ]
+                },
+                "grayscale": {
+                    "datasets": [
+                        "emnist>EMNISTDataset"
                     ]
                 }
             }

--- a/repromodel_core/requirements.txt
+++ b/repromodel_core/requirements.txt
@@ -11,6 +11,7 @@ charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
 comm==0.2.2
+coverage==7.5.3
 debugpy==1.8.1
 decorator==5.1.1
 easydict==1.13

--- a/repromodel_core/trainer.py
+++ b/repromodel_core/trainer.py
@@ -9,6 +9,7 @@ import argparse
 from src.getters import configure_component, get_optimizer, get_lr_scheduler, configure_device_specific, init_tensorboard_logging, load_json
 from src.utils import save_model, print_to_file, delete_command_outputs, load_state, get_last_dict_paths, load_and_replace_keys, replace_in_string, TqdmFile
 from copy import deepcopy
+import sys 
 
 SRC_DIR = "src."
 
@@ -87,6 +88,7 @@ def train(input_data):
     criterion = configure_component(loss_path, cfg.losses_params[cfg.losses])
 
     for m in range(model_min, len(cfg.models)):
+        print_to_file(f"Training started. Output in file {cfg.tensorboard_log_path}/{cfg.models[m]}_{cfg.datasets}_" + "command_output.txt")
         print_to_file("Training model " + cfg.models[m], config=cfg, model_num = m)
 
         # Custom file object for TQDM
@@ -260,5 +262,5 @@ if __name__ == '__main__':
 
     try:
         train(args.input_data)
-    except:
-        print_to_file("Trainer function failed. Exiting with an error!")
+    except Exception as e:
+        print_to_file(f"Trainer function failed. Exiting with an error: {e}")

--- a/src/components/first-time-modal/first-time-modal.jsx
+++ b/src/components/first-time-modal/first-time-modal.jsx
@@ -7,7 +7,7 @@ import CloseIcon from "@mui/icons-material/Close"
 import IconButton from "@mui/material/IconButton"
 import Modal from "@mui/material/Modal"
 import React from "react"
-import trainConfig from "../../../repromodel_core/train_config.json"
+import experimentConfig from "../../../repromodel_core/experiment_config.json"
 import Typography from "@mui/material/Typography"
 
 import { handleDownload } from "../../utils/download-helpers"
@@ -83,7 +83,7 @@ const FirstTimeModal = () => {
             DemoTrainingConfig.json
           </Typography>
           
-          <Button variant = "contained" className = "modal-button" onClick = { () => handleDownload(trainConfig, 'DemoTrainingConfig', 'json') }>
+          <Button variant = "contained" className = "modal-button" onClick = { () => handleDownload(experimentConfig, 'DemoTrainingConfig', 'json') }>
             Download
           </Button>
           


### PR DESCRIPTION
Implemented code extractor. 

Major changes: 

- using coverage library to get all files used in running trainer.py
- function to copy files implemented in repromodel_core/src/utils.py
- changes to trainer script to include better error logging
- changes to app.py backend to include '/copy-covered-files' endpoint
- saveing passed config to experiment_config.json file (we will use this for now on)
- changes to first-time-modal.jsx to include new file name (this might be changed later if we want only dummy config)

To Do:

- implement frontend
- include files and model checkpoints
- directly pushing the code to user's GitHub repo 